### PR TITLE
Fix rest parameter annotation with spaces

### DIFF
--- a/src/paramExtractor.ts
+++ b/src/paramExtractor.ts
@@ -14,6 +14,9 @@ export function grabPossibleParameters(fc: IFunctionCallObject, definitionLine: 
     paramList = splitToParamList(defintionParam);
 
     paramList = paramList.map((param) => {
+
+      param = param.replace(/\.\.\.\s+/, "...");
+
       // Extract identifiers
       const words = param.trim().split(" ");
 


### PR DESCRIPTION
This commit fixes a bug in which the name of a rest parameter isn't displayed properly if there's a space between the ... operator and parameter name.

(e.g. Now foo (... bar) { } now works exactly like foo (...bar).)