### PR TITLE
Fixing test that broke CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,6 +532,14 @@
         "through": "~2.3.1"
       }
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "execa": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
@@ -1495,6 +1503,11 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "merge-stream": {
       "version": "1.0.1",
@@ -2569,6 +2582,22 @@
         "source-map-support": "^0.5.0",
         "url-parse": "^1.4.3",
         "vinyl-source-stream": "^1.1.0"
+      }
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
   "dependencies": {
     "babylon": "^7.0.0-beta.47",
     "recast": "^0.15.3",
-    "tslint": "5.11.0"
+    "tslint": "5.11.0",
+    "watch": "^1.0.2"
   },
   "husky": {
     "hooks": {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -59,7 +59,10 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
                   console.log(arguments);
                 }
 
-                diagnostics.push(diag);
+                // If the diagnostic does not exist in the array yet, push it
+                if (!diagnostics.some((diagnostic) => JSON.stringify(diagnostic) === JSON.stringify(diag))) {
+                  diagnostics.push(diag);
+                }
               }
 
               if (willShowErrorAnnotation) {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -54,6 +54,11 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
             if (idx >= paramList.length) {
               if (currentEditor.document.languageId === "javascript" && willShowDiagnostics) {
                 const diag = new vscode.Diagnostic(currentArgRange, "[JS Param Annotations] Invalid parameter", vscode.DiagnosticSeverity.Error);
+
+                if (!diagnostics) {
+                  console.log(arguments);
+                }
+
                 diagnostics.push(diag);
               }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,8 +66,6 @@ async function run(ctx: vscode.ExtensionContext, editor: vscode.TextEditor | und
   // Get all of the text in said editor
   const sourceCode = editor.document.getText();
 
-  diagnostics = [];
-
   const [decArray, errDecArray] = await createDecorations(editor, sourceCode);
 
   if (editor.document.languageId === "javascript") {
@@ -80,6 +78,8 @@ async function run(ctx: vscode.ExtensionContext, editor: vscode.TextEditor | und
 }
 
 export async function createDecorations(editor: vscode.TextEditor, sourceCode: string): Promise<vscode.DecorationOptions[][]> {
+  diagnostics = [];
+
   const decArray: vscode.DecorationOptions[] = [];
   const errDecArray: vscode.DecorationOptions[] = [];
 
@@ -100,4 +100,13 @@ export async function createDecorations(editor: vscode.TextEditor, sourceCode: s
   }
 
   return [decArray, errDecArray];
+}
+
+export function getDiagnostics(): vscode.Diagnostic[] {
+  if (!diagnostics) {
+    return [];
+  }
+
+  // Returns a copy
+  return diagnostics.slice();
 }

--- a/src/test/e2e/extension.test.ts
+++ b/src/test/e2e/extension.test.ts
@@ -7,11 +7,7 @@ const testFolderLocation = "/../../../src/test/examples/";
 
 suite("js annotations", () => {
   test("should annotate function with parameters", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "normalParams.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("normalParams.js");
 
     assert.deepEqual(decArray.length, 1);
     assert.deepEqual(errDecArray.length, 0);
@@ -20,11 +16,7 @@ suite("js annotations", () => {
   });
 
   test("should not annotate function with no parameters", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "noParams.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("noParams.js");
 
     assert.deepEqual(decArray.length, 0);
     assert.deepEqual(errDecArray.length, 0);
@@ -33,27 +25,17 @@ suite("js annotations", () => {
   });
 
   test("should decorate with error decoration if more args than params", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "moreArgs.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("moreArgs.js");
 
     assert.deepEqual(decArray.length, 1);
-
-    // By Default the error decoration is hidden with the diagnostic in it's place
-    // TODO: Check for diagnostic
     assert.deepEqual(errDecArray.length, 0);
+    assert.deepEqual(Extension.getDiagnostics().length, 1);
 
     vscode.commands.executeCommand("workbench.action.closeActiveEditor");
   });
 
   test("should decorate with rest params", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "rest.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("rest.js");
 
     assert.deepEqual(decArray.length, 3);
     assert.deepEqual(errDecArray.length, 0);
@@ -62,11 +44,7 @@ suite("js annotations", () => {
   });
 
   test("should decorate function call with multiple lines", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "multipleLines.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("multipleLines.js");
 
     assert.deepEqual(decArray.length, 2);
     assert.deepEqual(errDecArray.length, 0);
@@ -75,11 +53,7 @@ suite("js annotations", () => {
   });
 
   test("should decorate with nested function calls", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "nested.ts"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("nested.ts");
 
     assert.deepEqual(decArray.length, 6);
     assert.deepEqual(errDecArray.length, 0);
@@ -88,11 +62,7 @@ suite("js annotations", () => {
   });
 
   test("should not annotate with call that has no definition", async () => {
-    const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + "noDefinition.js"));
-    const document = await vscode.workspace.openTextDocument(uri);
-    const editor = await vscode.window.showTextDocument(document);
-    await sleep(500);
-    const [decArray, errDecArray] = await Extension.createDecorations(editor, editor.document.getText());
+    const [decArray, errDecArray] = await getDecorationsFromExample("noDefinition.js");
 
     assert.deepEqual(decArray.length, 0);
     assert.deepEqual(errDecArray.length, 0);
@@ -105,4 +75,14 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+async function getDecorationsFromExample(exampleName: string): Promise<vscode.DecorationOptions[][]> {
+  const uri = vscode.Uri.file(path.join(__dirname + testFolderLocation + exampleName));
+  const document = await vscode.workspace.openTextDocument(uri);
+  const editor = await vscode.window.showTextDocument(document);
+  await sleep(500);
+  const decorations = await Extension.createDecorations(editor, editor.document.getText());
+
+  return decorations;
 }


### PR DESCRIPTION
Fixed the "should decorate with error decoration if more args than params" test, it was using the diagnostics array that was only being initialized through the "run" Method, moved its initialization to "createDecorations" method, so tests can pass.
Also cleaned and removed reused and repeated code.

Fixes #32