### PR TITLE
Add leading space in first annotation

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -35,6 +35,7 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
     }
 
     if (fc.paramLocations && fc.paramNames) {
+      let counter = 0;
       for (const ix in fc.paramLocations) {
         if (fc.paramLocations.hasOwnProperty(ix)) {
           const idx = parseInt(ix, 10);
@@ -72,9 +73,10 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
 
               continue;
             }
-            decoration = Annotations.paramAnnotation(" " + paramList[idx] + ": ", currentArgRange);
+            let spacer = (counter === 0) ? " " : "";
+            decoration = Annotations.paramAnnotation(spacer + paramList[idx] + ": ", currentArgRange);
           }
-
+          counter++;
           decArray.push(decoration);
         }
       }

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -73,7 +73,7 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
 
               continue;
             }
-            let spacer = (counter === 0) ? " " : "";
+            const spacer = (counter === 0) ? " " : "";
             decoration = Annotations.paramAnnotation(spacer + paramList[idx] + ": ", currentArgRange);
           }
           counter++;

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -72,7 +72,7 @@ export async function decorateFunctionCall(currentEditor: vscode.TextEditor, doc
 
               continue;
             }
-            decoration = Annotations.paramAnnotation(paramList[idx] + ": ", currentArgRange);
+            decoration = Annotations.paramAnnotation(" " + paramList[idx] + ": ", currentArgRange);
           }
 
           decArray.push(decoration);


### PR DESCRIPTION
Add leading space to the first annotation (after left paren)  This is just a small tweak, matching how the annotations work in PHPStorm (see screenshot)

![image](https://user-images.githubusercontent.com/183153/47322980-d7033d00-d60e-11e8-95f8-b43730be0d9c.png)
